### PR TITLE
chore(ci): enabled to use PAT instread of workflow default token.

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -18,5 +18,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           manifest-file: .release-please-manifest.json
           config-file: '.github/release-please-config.json'


### PR DESCRIPTION
## Issue/PR link
relates: #36 

## What does this PR do?
Describe what changes you make in your branch:
SSIA, since `assets-update.yaml` workflow had not been triggered after the merge of #44, and this is known issue of release-please-action.

## (Optional) Additional Contexts
Describe additional information for reviewers (i.e. What does not included)
N/A